### PR TITLE
Add commute model

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -15,11 +15,14 @@ end
 
 group :development, :test do
   gem "dotenv-rails"
+  gem "factory_girl_rails"
+  gem "pry-rails"
   gem "rspec-rails", "~> 3.2"
 end
 
-group :development do
-  gem "pry-rails"
+group :test do
+  gem "database_cleaner"
+  gem "shoulda-matchers"
 end
 
 # To use ActiveModel has_secure_password

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -41,11 +41,17 @@ GEM
     arel (6.0.0)
     builder (3.2.2)
     coderay (1.1.0)
+    database_cleaner (1.4.0)
     diff-lcs (1.2.5)
     dotenv (2.0.0)
     dotenv-rails (2.0.0)
       dotenv (= 2.0.0)
     erubis (2.7.0)
+    factory_girl (4.5.0)
+      activesupport (>= 3.0.0)
+    factory_girl_rails (4.5.0)
+      factory_girl (~> 4.5.0)
+      railties (>= 3.0.0)
     globalid (0.3.3)
       activesupport (>= 4.1.0)
     hike (1.2.3)
@@ -125,6 +131,8 @@ GEM
       rspec-mocks (~> 3.2.0)
       rspec-support (~> 3.2.0)
     rspec-support (3.2.2)
+    shoulda-matchers (2.8.0)
+      activesupport (>= 3.0.0)
     slop (3.6.0)
     sprockets (2.12.3)
       hike (~> 1.2)
@@ -146,7 +154,9 @@ PLATFORMS
 
 DEPENDENCIES
   active_model_serializers (~> 0.8.3)
+  database_cleaner
   dotenv-rails
+  factory_girl_rails
   newrelic_rpm
   pg (~> 0.18)
   pry-rails
@@ -155,3 +165,4 @@ DEPENDENCIES
   rails-api (~> 0.4.0)
   rails_12factor
   rspec-rails (~> 3.2)
+  shoulda-matchers

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,13 +6,7 @@ class ApplicationController < ActionController::API
   private
 
   def authenticate
-    unless check_token
-      render json: { error: "Unauthorized" }, status: 401
-    end
-  end
-
-  def check_token
-    authenticate_with_http_token do |request_token, _options|
+    authenticate_or_request_with_http_token do |request_token, _options|
       request_token.size == auth_token.size &&
         ActiveSupport::SecurityUtils.secure_compare(request_token, auth_token)
     end

--- a/app/controllers/commutes_controller.rb
+++ b/app/controllers/commutes_controller.rb
@@ -1,0 +1,32 @@
+class CommutesController < ApplicationController
+  def index
+    commutes = Commute.by_departed_at
+    render json: commutes
+  end
+
+  def create
+    commute = Commute.new(commute_params)
+
+    if commute.save
+      render json: commute, status: 201
+    else
+      render json: { errors: commute.errors.full_messages }, status: 422
+    end
+  end
+
+  def update
+    commute = Commute.find(params[:id])
+
+    if commute.update_attributes(commute_params)
+      render json: commute
+    else
+      render json: { errors: commute.errors.full_messages }, status: 422
+    end
+  end
+
+  private
+
+  def commute_params
+    params.require(:commute).permit(:arrived_at, :departed_at)
+  end
+end

--- a/app/models/commute.rb
+++ b/app/models/commute.rb
@@ -1,0 +1,7 @@
+class Commute < ActiveRecord::Base
+  validates :departed_at, presence: true
+
+  def self.by_departed_at
+    order(departed_at: :desc)
+  end
+end

--- a/app/serializers/commute_serializer.rb
+++ b/app/serializers/commute_serializer.rb
@@ -1,0 +1,3 @@
+class CommuteSerializer < ActiveModel::Serializer
+  attributes :id, :arrived_at, :departed_at
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   get "heartbeat" => "heartbeat#index"
   get "hello" => "home#hello"
+
+  resources :commutes, only: [:index, :create, :update]
 end

--- a/db/migrate/20150307200653_create_commutes.rb
+++ b/db/migrate/20150307200653_create_commutes.rb
@@ -1,0 +1,10 @@
+class CreateCommutes < ActiveRecord::Migration
+  def change
+    create_table :commutes do |t|
+      t.datetime :departed_at
+      t.datetime :arrived_at
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,9 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 0) do
+ActiveRecord::Schema.define(version: 20150307200653) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "commutes", force: :cascade do |t|
+    t.datetime "departed_at"
+    t.datetime "arrived_at"
+    t.datetime "created_at",  null: false
+    t.datetime "updated_at",  null: false
+  end
 
 end

--- a/spec/factories/commutes.rb
+++ b/spec/factories/commutes.rb
@@ -1,0 +1,9 @@
+FactoryGirl.define do
+  factory :commute do
+    departed_at { 30.minutes.ago }
+
+    trait :completed do
+      arrived_at { departed_at + 30.minutes }
+    end
+  end
+end

--- a/spec/models/commute_spec.rb
+++ b/spec/models/commute_spec.rb
@@ -1,0 +1,19 @@
+require "rails_helper"
+
+RSpec.describe Commute do
+  describe "validations" do
+    it { should validate_presence_of(:departed_at) }
+  end
+
+  describe ".by_departed_at" do
+    it "orders commutes by departed_at" do
+      second = create(:commute, :completed, departed_at: 1.day.ago)
+      first = create(:commute, :completed, departed_at: 1.hour.ago)
+
+      commutes = Commute.by_departed_at
+
+      expect(commutes[0]).to eq(first)
+      expect(commutes[1]).to eq(second)
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,7 +6,32 @@ require 'rspec/rails'
 
 ActiveRecord::Migration.maintain_test_schema!
 
+Dir["spec/support/**/*.rb"].each { |f| load f }
+
 RSpec.configure do |config|
   config.use_transactional_fixtures = true
   config.infer_spec_type_from_file_location!
+  config.include FactoryGirl::Syntax::Methods
+  config.include SpecAuthenticationHelper, type: :request
+  config.include ResponseHelpers, type: :request
+
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.around(:each) do |example|
+    DatabaseCleaner.cleaning do
+      example.run
+    end
+  end
+
+  config.before(:suite) do
+    begin
+      DatabaseCleaner.start
+      FactoryGirl.lint
+    ensure
+      DatabaseCleaner.clean
+    end
+  end
 end

--- a/spec/requests/authentication_spec.rb
+++ b/spec/requests/authentication_spec.rb
@@ -15,7 +15,6 @@ RSpec.describe "authentication" do
       get hello_path, nil, "HTTP_AUTHORIZATION" => "Token invalid-token"
 
       expect(response.status).to eq(401)
-      expect(JSON.parse(response.body)["error"]).to eq("Unauthorized")
     end
   end
 
@@ -24,7 +23,6 @@ RSpec.describe "authentication" do
       get hello_path
 
       expect(response.status).to eq(401)
-      expect(JSON.parse(response.body)["error"]).to eq("Unauthorized")
     end
   end
 end

--- a/spec/requests/commutes_spec.rb
+++ b/spec/requests/commutes_spec.rb
@@ -1,0 +1,132 @@
+require "rails_helper"
+
+RSpec.describe "commutes" do
+  describe "fetching commutes" do
+    let(:http_method) { :get }
+    let(:uri) { commutes_path }
+
+    it_should_behave_like "an authenticated endpoint"
+
+    context "when commutes exist" do
+      it "returns 200" do
+        create(:commute)
+
+        get commutes_path, nil, token_header
+
+        expect(response.status).to eq(200)
+      end
+
+      it "returns the commutes in reverse chronological order" do
+        second = create(:commute, :completed, departed_at: 1.day.ago)
+        first = create(:commute, :completed, departed_at: 1.hour.ago)
+
+        get commutes_path, nil, token_header
+
+        expect(json_response["commutes"][0]["id"]).to eq(first.id)
+        expect(json_response["commutes"][1]["id"]).to eq(second.id)
+      end
+    end
+
+    context "when no commutes exist" do
+      it "returns empty collection" do
+        get commutes_path, nil, token_header
+
+        expect(json_response["commutes"]).to be_empty
+      end
+    end
+  end
+
+  describe "creating commutes" do
+    let(:http_method) { :post }
+    let(:uri) { commutes_path }
+
+    it_should_behave_like "an authenticated endpoint"
+
+    context "with valid data" do
+      it "returns the commute" do
+        commute_params = { commute: { departed_at: Time.zone.now } }
+
+        post commutes_path, commute_params, token_header
+
+        expect(json_response["commute"]["id"]).not_to be_nil
+        expect(json_response["commute"]["departed_at"]).not_to be_nil
+      end
+
+      it "returns 201" do
+        commute_params = { commute: { departed_at: Time.zone.now } }
+
+        post commutes_path, commute_params, token_header
+
+        expect(response.status).to eq(201)
+      end
+    end
+
+    context "with invalid data" do
+      it "returns 422" do
+        commute_params = { commute: { departed_at: nil } }
+
+        post commutes_path, commute_params, token_header
+
+        expect(response.status).to eq(422)
+      end
+
+      it "includes the error message" do
+        commute_params = { commute: { departed_at: nil } }
+
+        post commutes_path, commute_params, token_header
+
+        expect(json_response["errors"].first).to include("can't be blank")
+      end
+    end
+  end
+
+  describe "updating commutes" do
+    let(:http_method) { :patch }
+    let(:uri) { commute_path(commute) }
+    let(:commute) { create(:commute) }
+
+    it_should_behave_like "an authenticated endpoint", :patch, :commute_path
+
+    context "with valid data" do
+      it "returns 200" do
+        update_params = {
+          commute: { arrived_at: Time.zone.now }
+        }
+
+        patch commute_path(commute), update_params, token_header
+
+        expect(response.status).to eq(200)
+      end
+
+      it "returns the updated commute" do
+        arrived_at = Time.zone.now
+        update_params = {
+          commute: { arrived_at: arrived_at }
+        }
+
+        patch commute_path(commute), update_params, token_header
+        expect(json_response["commute"]["id"]).not_to be_nil
+        expect(json_response["commute"]["departed_at"]).not_to be_nil
+        expect(json_response["commute"]["arrived_at"]).not_to be_nil
+      end
+    end
+
+    context "with invalid data" do
+      it "returns 422" do
+        update_params = { commute: { departed_at: nil } }
+
+        patch commute_path(commute), update_params, token_header
+
+        expect(response.status).to eq(422)
+      end
+
+      it "includes the error message" do
+        update_params = { commute: { departed_at: nil } }
+
+        patch commute_path(commute), update_params, token_header
+
+        expect(json_response["errors"].first).to include("can't be blank")
+      end
+    end
+  end
+end

--- a/spec/support/response_helpers.rb
+++ b/spec/support/response_helpers.rb
@@ -1,0 +1,5 @@
+module ResponseHelpers
+  def json_response
+    JSON.parse(response.body)
+  end
+end

--- a/spec/support/shared/authentication.rb
+++ b/spec/support/shared/authentication.rb
@@ -1,0 +1,17 @@
+RSpec.shared_examples "an authenticated endpoint" do
+  context "with invalid token" do
+    it "returns 401" do
+      send(http_method, uri, nil, "HTTP_AUTHORIZATION" => "Token nope-token")
+
+      expect(response.status).to eq(401)
+    end
+  end
+
+  context "with missing token" do
+    it "returns 401" do
+      send(http_method, uri, nil, {})
+
+      expect(response.status).to eq(401)
+    end
+  end
+end

--- a/spec/support/spec_authentication_helper.rb
+++ b/spec/support/spec_authentication_helper.rb
@@ -1,0 +1,5 @@
+module SpecAuthenticationHelper
+  def token_header
+    { "HTTP_AUTHORIZATION" => "Token #{ENV['AUTH_TOKEN']}" }
+  end
+end


### PR DESCRIPTION
* Adds factory_girl
* Adds database_cleaner
* Updates authentication to use Rails'
  `authenticate_or_request_with_http_token` method, which returns the
  `WWW-Authenticate` [header] required by the HTTP/1.1 spec
* Adds commutes index, create, and update actions
* Adds Commute.by_departed_at to order reverse chronologically by
  departed_at

[header]: http://www.w3.org/Protocols/rfc2616/rfc2616-sec10.html#sec10.4.2