### PR TITLE
Display commute days in browser's timezone

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,3 +14,21 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require_tree .
+
+$(function() {
+  var weekdays = [
+    "Sunday",
+    "Monday",
+    "Tuesday",
+    "Wednesday",
+    "Thursday",
+    "Friday",
+    "Saturday"
+  ];
+
+  $(".commute time").each(function() {
+    var commuteDate = new Date($(this).attr("datetime"));
+    var day = weekdays[commuteDate.getDay()];
+    $(this).text(day);
+  });
+});

--- a/app/presenters/commute_presenter.rb
+++ b/app/presenters/commute_presenter.rb
@@ -9,6 +9,10 @@ class CommutePresenter
     commute.departed_at.strftime("%A")
   end
 
+  def departed_at
+    commute.departed_at.iso8601
+  end
+
   def duration
     if commute.arrived_at.present?
       pluralize(duration_minutes, "minute")

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -14,7 +14,11 @@
   <table class="table table-striped">
     <% @latest_commutes.each do |commute| %>
       <tr class="commute">
-        <td><%= commute.day %></td>
+        <td>
+          <%= content_tag :time, datetime: commute.departed_at do %>
+            <%= commute.day %>
+          <% end %>
+        </td>
         <td><%= commute.duration %></td>
       </tr>
     <% end %>


### PR DESCRIPTION
Uses `<time>` element with the UTC timestamp and converts it the user's
day with JS. The element's original text is the UTC day, so if the JS
fails for some reason we should still show a value.