### PR TITLE
Allow deleting commutes

### DIFF
--- a/app/controllers/commutes_controller.rb
+++ b/app/controllers/commutes_controller.rb
@@ -1,0 +1,8 @@
+class CommutesController < ApplicationController
+  def destroy
+    commute = current_user.commutes.find(params[:id])
+    commute.destroy
+
+    redirect_to root_path, notice: "Commute deleted."
+  end
+end

--- a/app/presenters/commute_presenter.rb
+++ b/app/presenters/commute_presenter.rb
@@ -1,6 +1,8 @@
 class CommutePresenter
   include ActionView::Helpers::TextHelper
 
+  delegate :model_name, :to_key, :to_model, to: :commute
+
   def initialize(commute)
     @commute = commute
   end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -12,15 +12,18 @@
 
 <% if @latest_commutes.any? %>
   <table class="table table-striped">
-    <% @latest_commutes.each do |commute| %>
-      <tr class="commute">
-        <td>
-          <%= content_tag :time, datetime: commute.departed_at do %>
-            <%= commute.day %>
-          <% end %>
-        </td>
-        <td><%= commute.duration %></td>
-      </tr>
+    <%= content_tag_for :tr, @latest_commutes do |commute| %>
+      <td>
+        <%= content_tag :time, datetime: commute.departed_at do %>
+          <%= commute.day %>
+        <% end %>
+      </td>
+      <td><%= commute.duration %></td>
+      <td>
+        <%= link_to commute, method: :delete, class: "delete", data: { confirm: "Really?" } do %>
+          <span class="glyphicon glyphicon-remove text-danger"></span>
+        <% end %>
+      </td>
     <% end %>
   </table>
 <% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,5 +4,7 @@ Rails.application.routes.draw do
   post "departure" => "home#depart"
   post "arrival" => "home#arrive"
 
+  resources :commutes, only: [:destroy]
+
   root to: "home#index"
 end

--- a/spec/controllers/commutes_controller_spec.rb
+++ b/spec/controllers/commutes_controller_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+RSpec.describe CommutesController do
+  describe "#destroy" do
+    it "destroys the commute" do
+      user = create(:user)
+      commute = create(:commute, user: user)
+      sign_in_as user
+
+      delete :destroy, id: commute.id
+
+      expect(Commute.count).to eq 0
+    end
+
+    it "redirects to the root path" do
+      user = create(:user)
+      commute = create(:commute, user: user)
+      sign_in_as user
+
+      delete :destroy, id: commute.id
+
+      expect(controller).to redirect_to root_path
+    end
+  end
+end

--- a/spec/features/commutes_spec.rb
+++ b/spec/features/commutes_spec.rb
@@ -30,4 +30,15 @@ RSpec.describe "Commutes" do
 
     expect(page).to have_selector(".commute", count: 5)
   end
+
+  it "can be deleted" do
+    user = create(:user)
+    commute = create(:commute, user: user)
+
+    visit root_path(as: user)
+
+    within "#commute_#{commute.id}" do
+      expect(page).to have_selector "a.delete[data-method='delete']"
+    end
+  end
 end


### PR DESCRIPTION
It's not uncommon that I forget to log my arrival in the app until many
hours after the commute is over. When this happens, I want to be able to
delete the commute so it doesn't sour the data.

<hr/>

![commute-tracker-delete](https://cloud.githubusercontent.com/assets/72176/7800615/f463bf78-02cc-11e5-8b6c-571e78d683c5.gif)

