### PR TITLE
Add timezone to users

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,14 +4,16 @@ ruby "2.2.2"
 
 gem "bootstrap-sass"
 gem "clearance"
+gem "coffee-rails", "~> 4.1.0"
+gem "jquery-rails"
 gem "newrelic_rpm"
 gem "pg", "~> 0.18"
 gem "puma"
 gem "rails", "4.2.2"
-gem 'coffee-rails', '~> 4.1.0'
-gem 'jquery-rails'
-gem 'sass-rails', '~> 5.0'
-gem 'uglifier', '>= 1.3.0'
+gem "sass-rails", "~> 5.0"
+gem "tzinfo"
+gem "tzinfo-data"
+gem "uglifier", ">= 1.3.0"
 
 group :production do
   gem "rails_12factor"
@@ -22,7 +24,7 @@ group :development, :test do
   gem "factory_girl_rails"
   gem "pry-rails"
   gem "rspec-rails", "~> 3.2"
-  gem 'web-console', '~> 2.0'
+  gem "web-console", "~> 2.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -180,6 +180,8 @@ GEM
     tilt (1.4.1)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    tzinfo-data (1.2015.5)
+      tzinfo (>= 1.0.0)
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
@@ -212,6 +214,8 @@ DEPENDENCIES
   rspec-rails (~> 3.2)
   sass-rails (~> 5.0)
   shoulda-matchers
+  tzinfo
+  tzinfo-data
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,4 +2,10 @@ class User < ActiveRecord::Base
   include Clearance::User
 
   has_many :commutes, dependent: :destroy
+
+  validates(
+    :timezone,
+    inclusion: { in: TZInfo::Timezone.all_identifiers },
+    presence: true,
+  )
 end

--- a/db/migrate/20150628194304_add_timezone_to_users.rb
+++ b/db/migrate/20150628194304_add_timezone_to_users.rb
@@ -1,0 +1,5 @@
+class AddTimezoneToUsers < ActiveRecord::Migration
+  def change
+    add_column :users, :timezone, :string, null: false, default: "US/Pacific"
+  end
+end

--- a/db/structure.sql
+++ b/db/structure.sql
@@ -82,7 +82,8 @@ CREATE TABLE users (
     email character varying NOT NULL,
     encrypted_password character varying(128) NOT NULL,
     confirmation_token character varying(128),
-    remember_token character varying(128) NOT NULL
+    remember_token character varying(128) NOT NULL,
+    timezone character varying DEFAULT 'US/Pacific'::character varying NOT NULL
 );
 
 
@@ -182,4 +183,6 @@ INSERT INTO schema_migrations (version) VALUES ('20150307200653');
 INSERT INTO schema_migrations (version) VALUES ('20150404214043');
 
 INSERT INTO schema_migrations (version) VALUES ('20150421021158');
+
+INSERT INTO schema_migrations (version) VALUES ('20150628194304');
 

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -6,5 +6,6 @@ FactoryGirl.define do
   factory :user do
     email
     password "password"
+    timezone "UTC"
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,4 +4,13 @@ RSpec.describe User do
   describe "Associations" do
     it { should have_many(:commutes).dependent(:destroy) }
   end
+
+  describe "validations" do
+    it { should validate_presence_of(:timezone) }
+    it do
+      should validate_inclusion_of(:timezone).in_array(
+        TZInfo::Timezone.all_identifiers
+      )
+    end
+  end
 end


### PR DESCRIPTION
So far, I've gotten away without storing the user's timezone by
converting things to their local time in the browser. However, I want to
perform upcoming analytical operations on the server, for performance
reasons, and I'll need the user's timezone there.

Not providing anyway to edit the timezone in the app at this point, since
there's only two users.