### PR TITLE
Daily Averages Backend

### DIFF
--- a/app/models/daily_average.rb
+++ b/app/models/daily_average.rb
@@ -1,0 +1,5 @@
+class DailyAverage < ActiveRecord::Base
+  belongs_to :user
+
+  after_initialize :readonly!
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -2,6 +2,7 @@ class User < ActiveRecord::Base
   include Clearance::User
 
   has_many :commutes, dependent: :destroy
+  has_many :daily_averages
 
   validates(
     :timezone,

--- a/db/migrate/20150628200148_create_daily_averages_view.rb
+++ b/db/migrate/20150628200148_create_daily_averages_view.rb
@@ -1,0 +1,36 @@
+class CreateDailyAveragesView < ActiveRecord::Migration
+  def up
+    execute <<-CREATE_DAILY_AVERAGES
+      CREATE VIEW daily_averages AS
+        WITH
+        zone_converted AS (
+          SELECT
+            commutes.user_id,
+            (commutes.departed_at AT TIME ZONE 'UTC')
+              AT TIME ZONE users.timezone departed_at,
+            (commutes.arrived_at AT TIME ZONE 'UTC')
+              AT TIME ZONE users.timezone arrived_at
+          FROM
+            commutes
+            INNER JOIN users
+              ON users.id = commutes.user_id
+        )
+        SELECT
+          user_id,
+          CAST(EXTRACT(DOW FROM departed_at) AS INTEGER) day_of_week,
+          EXTRACT(EPOCH FROM AVG(arrived_at - departed_at) / 60) duration,
+          COUNT(*) count
+        FROM
+          zone_converted
+        GROUP BY
+          day_of_week,
+          user_id
+    CREATE_DAILY_AVERAGES
+  end
+
+  def down
+    execute <<-DROP_DAILY_AVERAGES
+      DROP VIEW daily_averages
+    DROP_DAILY_AVERAGES
+  end
+end

--- a/spec/models/daily_average_spec.rb
+++ b/spec/models/daily_average_spec.rb
@@ -1,0 +1,39 @@
+require "rails_helper"
+
+RSpec.describe DailyAverage do
+  describe "associations" do
+    it { should belong_to :user }
+  end
+
+  it { should be_readonly }
+
+  describe "#duration" do
+    it "is the average duration in minutes for commutes on a day of week" do
+      user = create(:user)
+      day_of_week = 1.hour.ago.wday
+      _today = create(
+        :commute,
+        user: user,
+        departed_at: 1.hour.ago,
+        arrived_at: 30.minutes.ago,
+      )
+      _yesterday = create(
+        :commute,
+        user: user,
+        departed_at: 1.hour.ago - 1.day,
+        arrived_at: 30.minutes.ago - 1.day,
+      )
+      _last_week = create(
+        :commute,
+        user: user,
+        departed_at: 1.hour.ago - 1.week,
+        arrived_at: 15.minutes.ago - 1.week,
+      )
+      expected_average = (30 + 45) / 2
+
+      daily_average = user.daily_averages.where(day_of_week: day_of_week).first
+
+      expect(daily_average.duration).to be_within(1).of(expected_average)
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,7 @@ require "rails_helper"
 RSpec.describe User do
   describe "Associations" do
     it { should have_many(:commutes).dependent(:destroy) }
+    it { should have_many(:daily_averages) }
   end
 
   describe "validations" do


### PR DESCRIPTION
Adds a database view with associated readonly model for calculating average commute times for days of the week.

This information is not included in the UI yet.