### PR TITLE
Add daily averages to root page

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ group :production do
 end
 
 group :development, :test do
+  gem "chronic"
   gem "dotenv-rails"
   gem "factory_girl_rails"
   gem "pry-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -53,6 +53,7 @@ GEM
       rack (>= 1.0.0)
       rack-test (>= 0.5.4)
       xpath (~> 2.0)
+    chronic (0.10.2)
     clearance (1.10.1)
       bcrypt
       email_validator (~> 1.4)
@@ -202,6 +203,7 @@ PLATFORMS
 DEPENDENCIES
   bootstrap-sass
   capybara
+  chronic
   clearance
   coffee-rails (~> 4.1.0)
   database_cleaner

--- a/app/controllers/home_controller.rb
+++ b/app/controllers/home_controller.rb
@@ -2,6 +2,7 @@ class HomeController < ApplicationController
   def index
     @latest_commutes = latest_commutes
     @in_progress_commute = user_commutes.in_progress.first
+    @daily_averages = user_daily_averages
   end
 
   def depart
@@ -26,5 +27,11 @@ class HomeController < ApplicationController
 
   def user_commutes
     current_user.commutes
+  end
+
+  def user_daily_averages
+    current_user.daily_averages.by_day.map do |daily_average|
+      DailyAveragePresenter.new(daily_average)
+    end
   end
 end

--- a/app/models/daily_average.rb
+++ b/app/models/daily_average.rb
@@ -2,4 +2,8 @@ class DailyAverage < ActiveRecord::Base
   belongs_to :user
 
   after_initialize :readonly!
+
+  def self.by_day
+    order(:day_of_week)
+  end
 end

--- a/app/presenters/daily_average_presenter.rb
+++ b/app/presenters/daily_average_presenter.rb
@@ -1,0 +1,23 @@
+class DailyAveragePresenter
+  delegate :model_name, :to_key, :to_model, to: :daily_average
+
+  def initialize(daily_average)
+    @daily_average = daily_average
+  end
+
+  def day
+    Date::DAYNAMES[@daily_average.day_of_week]
+  end
+
+  def duration
+    "#{rounded_duration} minutes"
+  end
+
+  private
+
+  def rounded_duration
+    @daily_average.duration.round(0)
+  end
+
+  attr_reader :daily_average
+end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -11,6 +11,8 @@
 <hr/>
 
 <% if @latest_commutes.any? %>
+  <h2>Recent Commutes</h2>
+
   <table class="table table-striped">
     <%= content_tag_for :tr, @latest_commutes do |commute| %>
       <td>
@@ -24,6 +26,17 @@
           <span class="glyphicon glyphicon-remove text-danger"></span>
         <% end %>
       </td>
+    <% end %>
+  </table>
+<% end %>
+
+<% if @daily_averages.any? %>
+  <h2>Daily Averages</h2>
+
+  <table class="table table-striped daily">
+    <%= content_tag_for :tr, @daily_averages do |daily_average| %>
+      <td><%= daily_average.day %></td>
+      <td><%= daily_average.duration %></td>
     <% end %>
   </table>
 <% end %>

--- a/spec/features/commutes_spec.rb
+++ b/spec/features/commutes_spec.rb
@@ -21,10 +21,7 @@ RSpec.describe "Commutes" do
 
   it "lists the last five commute times" do
     user = create(:user)
-
-    1.upto(5) do |num|
-      create(:commute, :completed, user: user, departed_at: num.days.ago)
-    end
+    create_list(:commute, 7, :completed, user: user)
 
     visit root_path(as: user)
 

--- a/spec/features/daily_averages_spec.rb
+++ b/spec/features/daily_averages_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+RSpec.describe "Daily averages" do
+  context "user is signed in" do
+    it "appears on the root page" do
+      user = create(:user)
+      create_commute_week(user)
+
+      visit root_path(as: user)
+
+      all(".daily tr").each_with_index do |row, index|
+        expect(row).to have_content commute_days[index]
+        expect(row).to have_content "30 minutes"
+      end
+    end
+  end
+
+  def commute_days
+    %w{Monday Tuesday Wednesday Thursday Friday}
+  end
+
+  def create_commute_week(user)
+    commute_days.each do |day|
+      create(:commute, :completed, user: user, departed_at: Chronic.parse(day))
+    end
+  end
+end

--- a/spec/models/daily_average_spec.rb
+++ b/spec/models/daily_average_spec.rb
@@ -42,4 +42,26 @@ RSpec.describe DailyAverage do
       expect(daily_average.duration).to be_within(1).of(expected_average)
     end
   end
+
+  describe ".by_day" do
+    it "orders the stats by day of week" do
+      create(:commute, :completed, departed_at: Chronic.parse("wednesday"))
+      create(:commute, :completed, departed_at: Chronic.parse("tuesday"))
+      create(:commute, :completed, departed_at: Chronic.parse("friday"))
+      create(:commute, :completed, departed_at: Chronic.parse("monday"))
+      create(:commute, :completed, departed_at: Chronic.parse("thursday"))
+
+      averages = DailyAverage.by_day
+
+      expect(averages[0].day_of_week).to eq 1
+      expect(averages[1].day_of_week).to eq 2
+      expect(averages[2].day_of_week).to eq 3
+      expect(averages[3].day_of_week).to eq 4
+      expect(averages[4].day_of_week).to eq 5
+    end
+  end
+
+  def create_commute_on(day)
+    create(:commute, :completed, departed_at: Chronic.parse(day))
+  end
 end

--- a/spec/presenters/daily_average_presenter_spec.rb
+++ b/spec/presenters/daily_average_presenter_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe DailyAveragePresenter do
+  describe "#day" do
+    it "returns the day name of the day of the week" do
+      daily_average = double("DailyAverage", day_of_week: 1)
+
+      presenter = DailyAveragePresenter.new(daily_average)
+
+      expect(presenter.day).to eq "Monday"
+    end
+  end
+
+  describe "#duration" do
+    it "returns the rounded duration in minutes" do
+      daily_average = double("DailyAverage", duration: 30.74)
+
+      presenter = DailyAveragePresenter.new(daily_average)
+
+      expect(presenter.duration).to eq "31 minutes"
+    end
+  end
+end


### PR DESCRIPTION
Includes averages of all the current user's commutes broken down by day
of week. I'm not entirely sure if this is useful information or not, but
it might be interesting.

<img width="374" alt="screenshot_7_12_15__12_44_pm" src="https://cloud.githubusercontent.com/assets/72176/8639600/d3c069f0-2893-11e5-98be-04e3a950409c.png">
