### PR TITLE
Use current user time zone

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -14,21 +14,3 @@
 //= require jquery_ujs
 //= require bootstrap-sprockets
 //= require_tree .
-
-$(function() {
-  var weekdays = [
-    "Sunday",
-    "Monday",
-    "Tuesday",
-    "Wednesday",
-    "Thursday",
-    "Friday",
-    "Saturday"
-  ];
-
-  $(".commute time").each(function() {
-    var commuteDate = new Date($(this).attr("datetime"));
-    var day = weekdays[commuteDate.getDay()];
-    $(this).text(day);
-  });
-});

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,5 +1,14 @@
 class ApplicationController < ActionController::Base
   include Clearance::Controller
 
+  around_action :use_current_user_time_zone, if: :signed_in?
   before_action :require_login
+
+  private
+
+  def use_current_user_time_zone
+    Time.use_zone(current_user.timezone) do
+      yield
+    end
+  end
 end


### PR DESCRIPTION
- Sets the timezone to the current user's zone for the duration of their
  request.
- Removes javascript to display the commute day in the user's time zone.
